### PR TITLE
Update git clone one-command to include the bundle folder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ To install, copy this repository into
 and name it `AMVScanner.bundle`.
 
 In one command,
-`git clone https://github.com/Alphadelta14/plex-amv-scanner.git /var/lib/plexmediaserver/Library/Application\ Support/Plex\ Media\ Server/Plug-ins`
+`git clone https://github.com/Alphadelta14/plex-amv-scanner.git /var/lib/plexmediaserver/Library/Application\ Support/Plex\ Media\ Server/Plug-ins/AMVScanner.bundle`


### PR DESCRIPTION
The single command 'git clone' example currently clones in to Plex's Plug-ins folder rather than into a dedicated bundle folder for the plugin. I've updated the command to clone in to the AMVScanner.bundle folder.

I've tested this with my local installation of Plex without issue. After using this command to clone, Plex successfully picked up the plugin after a restart.
